### PR TITLE
Modernize codebase: update Rust edition, refactor fetch functions, an…

### DIFF
--- a/tekstitv_235/Cargo.toml
+++ b/tekstitv_235/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nhl_2022"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.95"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tekstitv_235/src/games/fetch.rs
+++ b/tekstitv_235/src/games/fetch.rs
@@ -1,22 +1,29 @@
 use crate::utils::print_line;
-use reqwest::Url;
+use reqwest::{Client, StatusCode};
 
-pub async fn fetch_pages(page_number: usize, sub_index: usize, error_message: &str) -> Vec<String> {
+pub async fn fetch_pages(
+    client: &Client,
+    page_number: usize,
+    sub_index: usize,
+    _error_message: &str,
+) -> Result<Vec<String>, reqwest::Error> {
     let mut index = sub_index;
     let mut pages: Vec<String> = Vec::new();
+
     loop {
         let url_str = format!(
             "https://yle.fi/tekstitv/txt/{}_{:0>4}.htm",
             page_number, index
         );
-        let url = Url::parse(&url_str).unwrap();
-        let res = reqwest::get(url).await.expect(error_message);
+        let response = client.get(&url_str).send().await?;
 
-        if !res.status().is_success() {
+        if response.status() == StatusCode::NOT_FOUND {
             break;
         }
 
-        let html = res.text().await.unwrap_or("".to_string());
+        let response = response.error_for_status()?;
+        let html = response.text().await?;
+
         if html.is_empty() {
             break;
         }
@@ -25,5 +32,6 @@ pub async fn fetch_pages(page_number: usize, sub_index: usize, error_message: &s
         pages.push(html);
         index += 1;
     }
-    pages
+
+    Ok(pages)
 }

--- a/tekstitv_235/src/games/game.rs
+++ b/tekstitv_235/src/games/game.rs
@@ -10,7 +10,7 @@ pub enum GameStatus {
 }
 
 impl GameStatus {
-    pub(super) fn to_color(&self) -> &str {
+    pub(super) fn color_name(self) -> &'static str {
         match self {
             GameStatus::Completed => "bright green",
             GameStatus::NotStarted => "bright white",
@@ -28,17 +28,17 @@ pub struct Game {
 
 impl Game {
     pub fn from_lines(
-        lines: &Vec<&str>,
-        finnish_players: &Vec<String>,
+        lines: &[&str],
+        finnish_players: &[String],
         regex_factory: &RegexFactory,
     ) -> Option<Self> {
         let mut line_number: usize = 0;
         let period_results = parse_period_results(lines, regex_factory, &mut line_number);
         if let Some(teams) = Teams::from_lines(lines, &mut line_number) {
-            let status = parse_status(&period_results, teams.get_result(), regex_factory);
+            let status = parse_status(period_results.as_deref(), teams.get_result(), regex_factory);
             let scorers = Scorers::from_lines(
                 lines,
-                &regex_factory,
+                regex_factory,
                 finnish_players,
                 teams.get_is_overtime(),
                 &mut line_number,
@@ -63,9 +63,8 @@ impl Game {
     }
 
     pub fn print(&self) {
-        let res = self.period_results.as_ref();
-        if res.is_some() {
-            println!("{period_results}", period_results = res.unwrap().yellow());
+        if let Some(period_results) = self.period_results.as_ref() {
+            println!("{period_results}", period_results = period_results.yellow());
         }
 
         self.teams.print(&self.status);
@@ -78,13 +77,13 @@ impl Game {
 }
 
 fn parse_period_results(
-    lines: &Vec<&str>,
+    lines: &[&str],
     regex_factory: &RegexFactory,
     line_number: &mut usize,
 ) -> Option<String> {
-    if lines.len() > 0 {
+    if !lines.is_empty() {
         let regx = &regex_factory.regex_on_going_matches_by_time;
-        let trimmed_line = lines[0].trim_start();
+        let trimmed_line = lines.first()?.trim_start();
         if regx.is_match(trimmed_line) {
             *line_number += 1;
             return Some(trimmed_line.to_owned());
@@ -94,7 +93,7 @@ fn parse_period_results(
 }
 
 fn parse_status(
-    period_results: &Option<String>,
+    period_results: Option<&str>,
     result: &str,
     regex_factory: &RegexFactory,
 ) -> GameStatus {

--- a/tekstitv_235/src/games/game_list.rs
+++ b/tekstitv_235/src/games/game_list.rs
@@ -1,6 +1,6 @@
 use super::game::{Game, GameStatus};
 use crate::MESSAGE;
-use rand::RngExt;
+use rand::seq::IteratorRandom;
 
 pub struct GameList {
     games: Vec<Game>,
@@ -27,23 +27,16 @@ impl GameList {
             return MESSAGE;
         }
 
-        let on_going_games = self
+        let mut rng = rand::rng();
+        self
             .games
             .iter()
             .filter(|game| game.get_status() == GameStatus::Started)
-            .collect::<Vec<_>>();
-
-        if on_going_games.is_empty() {
-            return MESSAGE;
-        }
-
-        let len = on_going_games.len();
-        let mut rng = rand::rng();
-        let game = &on_going_games[rng.random_range(0..len)];
-        game.get_home_team_name()
+            .choose(&mut rng)
+            .map_or(MESSAGE, |game| game.get_home_team_name())
     }
 
     pub(crate) fn all_games_completed(&self) -> bool {
-        self.games.len() == 0 || self.games.iter().all(|game| game.is_completed())
+        self.games.is_empty() || self.games.iter().all(|game| game.is_completed())
     }
 }

--- a/tekstitv_235/src/games/game_parser.rs
+++ b/tekstitv_235/src/games/game_parser.rs
@@ -4,56 +4,77 @@ use crate::constants::{COL_WIDTH_PLAYER, COL_WIDTH_PLAYER_NAME};
 use crate::games::game::Game;
 use crate::regex_factory::RegexFactory;
 use crate::utils::{is_empty_or_whitespace, print_loading};
+use reqwest::Client;
 use scraper::{Html, Selector};
+use std::error::Error;
+use std::sync::LazyLock;
 
-pub async fn fetch_games(use_mock_data: bool) -> GameList {
+type AppResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+static BOXBOX_PRE_SELECTOR: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse(".boxbox > pre").expect("selector literal should parse"));
+
+pub async fn fetch_games(use_mock_data: bool) -> AppResult<GameList> {
     print_loading();
+    let client = create_http_client()?;
     let regex_factory = RegexFactory::new();
-    let game_lines = fetch_game_pages(use_mock_data).await;
-    let finnish_players = fetch_finnish_players().await;
+    let (game_lines, finnish_players) = tokio::try_join!(
+        fetch_game_pages(&client, use_mock_data),
+        fetch_finnish_players(&client)
+    )?;
+
     let mut games = GameList::new();
     parse_games(&mut games, &game_lines, &finnish_players, &regex_factory);
-    games
+    Ok(games)
 }
 
-async fn fetch_game_pages(use_mock_data: bool) -> Vec<String> {
+fn create_http_client() -> Result<Client, reqwest::Error> {
+    Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(20))
+        .user_agent("tekstitv_235/1.0")
+        .build()
+}
+
+async fn fetch_game_pages(client: &Client, use_mock_data: bool) -> AppResult<Vec<String>> {
     let page_number = 235;
     let sub_index = 1;
     let error_message = "Failed to load results from YLE web site";
-    let mut pages = fetch_pages(page_number, sub_index, error_message).await;
+    let mut pages = fetch_pages(client, page_number, sub_index, error_message).await?;
+
     if use_mock_data {
         // for some testing
-        let contents = std::fs::read_to_string("./assets/sivu0001.htm")
-            .expect("Something went wrong reading the file");
+        let contents = std::fs::read_to_string("./assets/sivu0001.htm")?;
         pages.push(contents);
     }
-    parse_lines(&pages)
+
+    Ok(parse_lines(&pages))
 }
 
-async fn fetch_finnish_players() -> Vec<String> {
+async fn fetch_finnish_players(client: &Client) -> AppResult<Vec<String>> {
     let page_number = 238;
     let sub_index = 2;
     let error_message = "Failed to load finnish players from YLE web site";
-    let pages = fetch_pages(page_number, sub_index, error_message).await;
-    parse_player_lines(&pages)
+    let pages = fetch_pages(client, page_number, sub_index, error_message).await?;
+    Ok(parse_player_lines(&pages))
 }
 
-pub async fn fetch_future_game_pages() -> Vec<String> {
+pub async fn fetch_future_game_pages() -> AppResult<Vec<String>> {
+    let client = create_http_client()?;
     let page_number = 237;
     let sub_index = 3;
     let error_message = "Failed to load future games from YLE web site";
-    let pages = fetch_pages(page_number, sub_index, error_message).await;
-    parse_lines(&pages)
+    let pages = fetch_pages(&client, page_number, sub_index, error_message).await?;
+    Ok(parse_lines(&pages))
 }
 
-fn parse_lines(pages: &Vec<String>) -> Vec<String> {
-    let selector = Selector::parse(".boxbox > pre").unwrap();
+fn parse_lines(pages: &[String]) -> Vec<String> {
     let mut lines: Vec<String> = Vec::new();
 
     for page in pages {
-        let document = Html::parse_document(&page);
+        let document = Html::parse_document(page);
         let filtering = document
-            .select(&selector)
+            .select(&BOXBOX_PRE_SELECTOR)
             .flat_map(|element| element.text().flat_map(|text| text.lines()))
             .filter(|line| !line.contains("NHL"));
 
@@ -71,8 +92,7 @@ fn parse_lines(pages: &Vec<String>) -> Vec<String> {
     lines
 }
 
-fn parse_player_lines(pages: &Vec<String>) -> Vec<String> {
-    let selector = Selector::parse(".boxbox > pre").unwrap();
+fn parse_player_lines(pages: &[String]) -> Vec<String> {
     let mut lines: Vec<String> = Vec::new();
 
     for page in pages {
@@ -81,9 +101,9 @@ fn parse_player_lines(pages: &Vec<String>) -> Vec<String> {
             continue;
         }
 
-        let document = Html::parse_document(&page);
+        let document = Html::parse_document(page);
         document
-            .select(&selector)
+            .select(&BOXBOX_PRE_SELECTOR)
             .flat_map(|element| element.text().flat_map(|text| text.lines()))
             .filter(|line| {
                 !is_empty_or_whitespace(line)
@@ -91,16 +111,14 @@ fn parse_player_lines(pages: &Vec<String>) -> Vec<String> {
                     && !line.contains("NHL")
             })
             .for_each(|line| {
-                lines.push(
-                    line.trim()
-                        .chars()
-                        .take(COL_WIDTH_PLAYER_NAME)
-                        .collect::<String>()
-                        .split(" ")
-                        .nth(1)
-                        .unwrap()
-                        .to_owned(),
-                )
+                let shortened = line
+                    .trim()
+                    .chars()
+                    .take(COL_WIDTH_PLAYER_NAME)
+                    .collect::<String>();
+                if let Some(player_name) = shortened.split_whitespace().nth(1) {
+                    lines.push(player_name.to_owned());
+                }
             });
     }
     lines
@@ -108,19 +126,23 @@ fn parse_player_lines(pages: &Vec<String>) -> Vec<String> {
 
 fn parse_games(
     games: &mut GameList,
-    game_lines: &Vec<String>,
-    finnish_players: &Vec<String>,
+    game_lines: &[String],
+    finnish_players: &[String],
     regex_factory: &RegexFactory,
 ) {
     let mut lines: Vec<&str> = Vec::new();
     for line in game_lines {
         if !lines.is_empty() && is_empty_or_whitespace(line) {
-            if let Some(game) = Game::from_lines(&lines, finnish_players, &regex_factory) {
+            if let Some(game) = Game::from_lines(&lines, finnish_players, regex_factory) {
                 games.push(game);
             }
             lines.clear();
         } else if !is_empty_or_whitespace(line) {
             lines.push(line);
         }
+    }
+
+    if let Some(game) = Game::from_lines(&lines, finnish_players, regex_factory) {
+        games.push(game);
     }
 }

--- a/tekstitv_235/src/games/scorers.rs
+++ b/tekstitv_235/src/games/scorers.rs
@@ -11,7 +11,7 @@ impl Scorer {
     fn new(
         line: &str,
         regex_factory: &RegexFactory,
-        finnish_players: &Vec<String>,
+        finnish_players: &[String],
         is_on_overtime: bool,
     ) -> Self {
         let is_finnish_player = is_finnish_player(line, finnish_players);
@@ -23,7 +23,7 @@ impl Scorer {
         }
     }
 
-    fn to_string(&self) -> String {
+    fn colorized_text(&self) -> String {
         if self.is_overtime {
             format!("{name}", name = self.name.bright_magenta())
         } else if self.is_finnish_player {
@@ -34,7 +34,7 @@ impl Scorer {
     }
 }
 
-fn is_finnish_player(line: &str, finnish_players: &Vec<String>) -> bool {
+fn is_finnish_player(line: &str, finnish_players: &[String]) -> bool {
     line.len() > 2
         && (line.starts_with("(")
             || line.starts_with(" (")
@@ -48,9 +48,9 @@ pub struct Scorers {
 
 impl Scorers {
     pub(super) fn from_lines(
-        lines: &Vec<&str>,
+        lines: &[&str],
         regex_factory: &RegexFactory,
-        finnish_players: &Vec<String>,
+        finnish_players: &[String],
         is_on_overtime: bool,
         line_number: &mut usize,
     ) -> Self {
@@ -69,17 +69,17 @@ impl Scorers {
         for (home, away) in &self.scorers {
             println!(
                 "{home_score} {away_score}",
-                home_score = home.to_string(),
-                away_score = away.to_string()
+                home_score = home.colorized_text(),
+                away_score = away.colorized_text()
             );
         }
     }
 }
 
 fn parse_scores(
-    lines: &Vec<&str>,
+    lines: &[&str],
     regex_factory: &RegexFactory,
-    finnish_players: &Vec<String>,
+    finnish_players: &[String],
     is_on_overtime: bool,
     line_number: &mut usize,
 ) -> Vec<(Scorer, Scorer)> {

--- a/tekstitv_235/src/games/teams.rs
+++ b/tekstitv_235/src/games/teams.rs
@@ -39,22 +39,19 @@ pub struct Teams {
 }
 
 impl Teams {
-    pub(super) fn from_lines(lines: &Vec<&str>, line_number: &mut usize) -> Option<Self> {
+    pub(super) fn from_lines(lines: &[&str], line_number: &mut usize) -> Option<Self> {
         let curr_line = *line_number;
         if lines.len() <= curr_line {
             return None;
         }
 
         let line = &lines[curr_line];
-        let teams = line.split(" - ").collect::<Vec<_>>();
-        if teams.len() < 2 {
-            return None;
-        }
+        let (home_raw, away_and_result_raw) = line.split_once(" - ")?;
+        let (away_raw, result_raw) = away_and_result_raw.rsplit_once("  ")?;
 
-        let away_team_and_result_or_time = teams[1].split("  ").collect::<Vec<_>>();
-        let home_team = teams[0].trim().to_owned();
-        let away_team = away_team_and_result_or_time[0].trim().to_owned();
-        let result = GameResult::new(away_team_and_result_or_time.last().unwrap().trim());
+        let home_team = home_raw.trim().to_owned();
+        let away_team = away_raw.trim().to_owned();
+        let result = GameResult::new(result_raw.trim());
         *line_number += 1;
 
         Some(Teams {
@@ -77,7 +74,7 @@ impl Teams {
     }
 
     pub(super) fn print(&self, status: &GameStatus) {
-        let color = status.to_color();
+        let color = status.color_name();
         println!(
             "{home_team:<COL_WIDTH_HOME$} - {away_team:<COL_WIDTH_AWAY$}{result}",
             home_team = self.home_team.color(color),

--- a/tekstitv_235/src/main.rs
+++ b/tekstitv_235/src/main.rs
@@ -1,8 +1,9 @@
-use colored::*;
+use colored::Colorize;
 use games::{
     game_list::GameList,
     game_parser::{fetch_future_game_pages, fetch_games},
 };
+use std::error::Error;
 use utils::print_tonight;
 
 use crate::utils::{print_line, print_selection, print_tomorrow};
@@ -12,22 +13,23 @@ pub mod games;
 pub mod regex_factory;
 pub mod utils;
 
-const MESSAGE: &'static str = "Jäämiehet hommissa...";
+const MESSAGE: &str = "Jäämiehet hommissa...";
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let use_mock_data = false;
-    let games = fetch_games(use_mock_data).await;
+    let games = fetch_games(use_mock_data).await?;
 
     print_games(&games);
 
     if games.all_games_completed() {
-        let future_games = fetch_future_game_pages().await;
+        let future_games = fetch_future_game_pages().await?;
         if !future_games.is_empty() {
             print_future_games(&future_games);
         }
     }
-    print_next_target(&games)
+    print_next_target(&games);
+    Ok(())
 }
 
 fn print_games(games: &GameList) {
@@ -49,7 +51,7 @@ fn print_next_target(games: &GameList) {
     print_line();
 }
 
-fn print_future_games(future_games: &Vec<String>) {
+fn print_future_games(future_games: &[String]) {
     print_tomorrow();
     for line in future_games {
         if line.contains("siir.") {

--- a/tekstitv_235/src/regex_factory.rs
+++ b/tekstitv_235/src/regex_factory.rs
@@ -5,11 +5,18 @@ pub struct RegexFactory {
     pub regex_overtime_goal: Regex,
 }
 
+impl Default for RegexFactory {
+    fn default() -> Self {
+        Self {
+            regex_on_going_matches_by_time: Regex::new(r"^\d{2}\.\d{2}")
+                .expect("time regex should compile"),
+            regex_overtime_goal: Regex::new(r"6[0-5]$").expect("overtime regex should compile"),
+        }
+    }
+}
+
 impl RegexFactory {
     pub fn new() -> Self {
-        RegexFactory {
-            regex_on_going_matches_by_time: Regex::new(r"^[0-9]{2}.[0-9]{2}").unwrap(),
-            regex_overtime_goal: Regex::new(r"([6]{1}[0-5]{1})$").unwrap(),
-        }
+        Self::default()
     }
 }


### PR DESCRIPTION
- Upgraded crate edition to Rust 2024.
- Modernized app entrypoint and error handling:
- Switched to explicit trait import for colored.
- Changed main to return Result and propagate fetch errors.
- Updated helper API from Vec reference to slice where appropriate.
- Reworked HTTP fetching
- Reused a reqwest Client instead of repeated reqwest::get calls.
- Added proper status handling with 404 pagination stop.
- Removed panic-prone unwrap/expect paths in network flow.
- Refactored parser flow in game_parser.rs
- Added shared selector via LazyLock.
- Added a client builder with timeouts and user-agent.
- Fetched independent data concurrently with tokio::try_join!.
- Converted parser function parameters from Vec references to slices.
- Made player extraction safer by removing unwrap in parsing chain.
- Fixed end-of-input case so last game block is parsed even without trailing blank line.
- Updated data model parsing signatures and option handling in game.rs.
- Removed allocation-heavy random selection in game_list.rs using iterator sampling.
- Converted scorer APIs to slices and cleaned method naming in scorers.rs.
- Modernized team-line parsing using split_once and rsplit_once in teams.rs.
- Improved regex initialization and defaults in regex_factory.rs.